### PR TITLE
Fix for the infinite upload bug

### DIFF
--- a/upload.js
+++ b/upload.js
@@ -46,7 +46,6 @@ getFilename = function (data, noDate) {
     var name = (noDate) ? '' : date + '_';
     name += getValue(data, 'name', FILE_NAME_LIMIT).toLowerCase();
     name = name.replace(/[^a-z0-9]/g, '_');
-    name = name.replace(/(?:[0-9]+_){2}/g, date + '_');
     var n = name.lastIndexOf('_');
     if (n > -1) {
         name = name.substring(0, n) + '.' + name.substring(n + 1);


### PR DESCRIPTION
Should fix #44 and #74.

The problem was indeed coming from the file name but it was more interesting than a special-character-problem.
The call to `name = name.replace(/(?:[0-9]+_){2}/g, date + '_');` was changing the file name several times.
The most minimal example that reproduces the bug that I found is : `0-1.jpg`.
Here is what happens:
- The filename is prefixed with the date: `xxx_0_1_jpg`
- Then we have a first call to the above mentioned line, the filename becomes `xxx_1.jpg`. The file is saved once with this name.
- When uploading a second chunk, the `replace` is called again, and the names finally becomes `xxx.jpg`
Therefore, the uploaded file name was not consistent throughout the upload process, this caused `File not found` errors.

I don't know what the goal of the faulty line was, I can't tell if removing it would break anything else.