### PR TITLE
Fixing 500 errors on image show pages.

### DIFF
--- a/views/show.jade
+++ b/views/show.jade
@@ -3,9 +3,9 @@ block content
 
   - var log = []
   - if (image.log) log = JSON.parse(image.log)
-
+  
   script(type='text/javascript').
-    mode = "#{log[log.length-1].split('&')[0].split('=')[1]}"
+    mode = "#{log.length > 0 ? log[log.length-1].split('&')[0].split('=')[1] : ''}"
     params = parametersObject("#{log[log.length-1]}")
     src = "/upload/#{image.filename}"
     fetch_image(src,mode)


### PR DESCRIPTION
It should fix #75 and #69.

Parsing for `mode` when `log` was an empty array caused a 500 error (on `cannot call split of undefined`).
Replacing with a default empty value allows the image page to be displayed.